### PR TITLE
Building size standard

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,18 @@
-# Automatically normalize line endings across platforms
+# Set default behavior to automatically normalize line endings.
 * text=auto
 
-# Treat specific files as binary to avoid line ending conversions
-*.obj binary
-*.mtl binary
-*.meta binary
-*.unitypackage binary
-*.apk binary
-*.aab binary
+# Explicitly declare text files you want to always be normalized and converted to LF on checkout.
+*.cs     text
+*.shader text
+*.gltf  text
+
+# Declare binary files to be treated as binary and not modified.
+*.fbx    binary
+*.mtl    binary
+*.png    binary
+*.jpg    binary
+*.jpeg   binary
+*.gif    binary
+*.ico    binary
+*.dll    binary
+*.exe    binary

--- a/.gitignore
+++ b/.gitignore
@@ -72,5 +72,3 @@ crashlytics-build.properties
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
 
-# Ignore specific imported assets if path length is an issue
-/Assets/Art/3D/KayKit_Medieval_Hexagon_Pack_1.0_FREE/

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ crashlytics-build.properties
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
 
+# Ignore specific imported assets as path length is an issue
+/Assets/Art/3D/KayKit_Medieval_Hexagon_Pack_1.0_FREE/

--- a/Assets/Editor.meta
+++ b/Assets/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 812111fbafb71cd45a6d218599d8511a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/HexGridSnapper.cs
+++ b/Assets/Editor/HexGridSnapper.cs
@@ -1,0 +1,73 @@
+using UnityEditor;
+using UnityEngine;
+
+[InitializeOnLoad]
+public class HexGridSnapper
+{
+    private static bool isSnappingEnabled = true; // Snapping is enabled by default
+
+    static HexGridSnapper()
+    {
+        SceneView.duringSceneGui += OnSceneGUI;
+    }
+
+    // Toggle snapping via menu item
+    [MenuItem("Tools/Hex Grid Snapping/Toggle Snapping %#h")] // Ctrl + Shift + H
+    public static void ToggleSnapping()
+    {
+        isSnappingEnabled = !isSnappingEnabled;
+        Debug.Log("Hex Grid Snapping " + (isSnappingEnabled ? "Enabled" : "Disabled"));
+    }
+
+    private static void OnSceneGUI(SceneView sceneView)
+    {
+        if (!isSnappingEnabled)
+            return;
+
+        Event e = Event.current;
+
+        // Check if an object is being moved
+        if (e.type == EventType.MouseUp && e.button == 0 && Selection.activeTransform != null)
+        {
+            foreach (var transform in Selection.transforms)
+            {
+                SnapTransformToHexGrid(transform);
+            }
+        }
+    }
+
+    private static void SnapTransformToHexGrid(Transform transform)
+    {
+        // Replace '1f' with your hexagon side length if different
+        float a = 6.5f; // Side length of your hexagon
+        float size = a;
+
+        // Calculate hex dimensions
+        float width = 2f * size;
+        float height = Mathf.Sqrt(3f) * size;
+
+        Vector3 position = transform.position;
+
+        // Convert world position to hex grid coordinates
+        float q = (2f / 3f * position.x) / size;
+        float r = (-1f / 3f * position.x + Mathf.Sqrt(3f) / 3f * position.z) / size;
+
+        // Round to nearest hex grid coordinate
+        int qInt = Mathf.RoundToInt(q);
+        int rInt = Mathf.RoundToInt(r);
+
+        // Convert hex grid coordinates back to world position
+        Vector3 snappedPosition = HexToWorldPosition(qInt, rInt, size);
+
+        // Record the change for undo functionality
+        Undo.RecordObject(transform, "Snap to Hex Grid");
+        transform.position = snappedPosition;
+    }
+
+    private static Vector3 HexToWorldPosition(int q, int r, float size)
+    {
+        float x = size * (3f / 2f) * q;
+        float z = size * Mathf.Sqrt(3f) * (r + q / 2f);
+        return new Vector3(x, 0f, z);
+    }
+}

--- a/Assets/Editor/HexGridSnapper.cs
+++ b/Assets/Editor/HexGridSnapper.cs
@@ -1,73 +1,73 @@
-using UnityEditor;
-using UnityEngine;
+// using UnityEditor;
+// using UnityEngine;
 
-[InitializeOnLoad]
-public class HexGridSnapper
-{
-    private static bool isSnappingEnabled = true; // Snapping is enabled by default
+// [InitializeOnLoad]
+// public class HexGridSnapper
+// {
+//     private static bool isSnappingEnabled = true; // Snapping is enabled by default
 
-    static HexGridSnapper()
-    {
-        SceneView.duringSceneGui += OnSceneGUI;
-    }
+//     static HexGridSnapper()
+//     {
+//         SceneView.duringSceneGui += OnSceneGUI;
+//     }
 
-    // Toggle snapping via menu item
-    [MenuItem("Tools/Hex Grid Snapping/Toggle Snapping %#h")] // Ctrl + Shift + H
-    public static void ToggleSnapping()
-    {
-        isSnappingEnabled = !isSnappingEnabled;
-        Debug.Log("Hex Grid Snapping " + (isSnappingEnabled ? "Enabled" : "Disabled"));
-    }
+//     // Toggle snapping via menu item
+//     [MenuItem("Tools/Hex Grid Snapping/Toggle Snapping %#h")] // Ctrl + Shift + H
+//     public static void ToggleSnapping()
+//     {
+//         isSnappingEnabled = !isSnappingEnabled;
+//         Debug.Log("Hex Grid Snapping " + (isSnappingEnabled ? "Enabled" : "Disabled"));
+//     }
 
-    private static void OnSceneGUI(SceneView sceneView)
-    {
-        if (!isSnappingEnabled)
-            return;
+//     private static void OnSceneGUI(SceneView sceneView)
+//     {
+//         if (!isSnappingEnabled)
+//             return;
 
-        Event e = Event.current;
+//         Event e = Event.current;
 
-        // Check if an object is being moved
-        if (e.type == EventType.MouseUp && e.button == 0 && Selection.activeTransform != null)
-        {
-            foreach (var transform in Selection.transforms)
-            {
-                SnapTransformToHexGrid(transform);
-            }
-        }
-    }
+//         // Check if an object is being moved
+//         if (e.type == EventType.MouseUp && e.button == 0 && Selection.activeTransform != null)
+//         {
+//             foreach (var transform in Selection.transforms)
+//             {
+//                 SnapTransformToHexGrid(transform);
+//             }
+//         }
+//     }
 
-    private static void SnapTransformToHexGrid(Transform transform)
-    {
-        // Replace '1f' with your hexagon side length if different
-        float a = 6.5f; // Side length of your hexagon
-        float size = a;
+//     private static void SnapTransformToHexGrid(Transform transform)
+//     {
+//         // Replace '1f' with your hexagon side length if different
+//         float a = 6.5f; // Side length of your hexagon
+//         float size = a;
 
-        // Calculate hex dimensions
-        float width = 2f * size;
-        float height = Mathf.Sqrt(3f) * size;
+//         // Calculate hex dimensions
+//         float width = 2f * size;
+//         float height = Mathf.Sqrt(3f) * size;
 
-        Vector3 position = transform.position;
+//         Vector3 position = transform.position;
 
-        // Convert world position to hex grid coordinates
-        float q = (2f / 3f * position.x) / size;
-        float r = (-1f / 3f * position.x + Mathf.Sqrt(3f) / 3f * position.z) / size;
+//         // Convert world position to hex grid coordinates
+//         float q = (2f / 3f * position.x) / size;
+//         float r = (-1f / 3f * position.x + Mathf.Sqrt(3f) / 3f * position.z) / size;
 
-        // Round to nearest hex grid coordinate
-        int qInt = Mathf.RoundToInt(q);
-        int rInt = Mathf.RoundToInt(r);
+//         // Round to nearest hex grid coordinate
+//         int qInt = Mathf.RoundToInt(q);
+//         int rInt = Mathf.RoundToInt(r);
 
-        // Convert hex grid coordinates back to world position
-        Vector3 snappedPosition = HexToWorldPosition(qInt, rInt, size);
+//         // Convert hex grid coordinates back to world position
+//         Vector3 snappedPosition = HexToWorldPosition(qInt, rInt, size);
 
-        // Record the change for undo functionality
-        Undo.RecordObject(transform, "Snap to Hex Grid");
-        transform.position = snappedPosition;
-    }
+//         // Record the change for undo functionality
+//         Undo.RecordObject(transform, "Snap to Hex Grid");
+//         transform.position = snappedPosition;
+//     }
 
-    private static Vector3 HexToWorldPosition(int q, int r, float size)
-    {
-        float x = size * (3f / 2f) * q;
-        float z = size * Mathf.Sqrt(3f) * (r + q / 2f);
-        return new Vector3(x, 0f, z);
-    }
-}
+//     private static Vector3 HexToWorldPosition(int q, int r, float size)
+//     {
+//         float x = size * (3f / 2f) * q;
+//         float z = size * Mathf.Sqrt(3f) * (r + q / 2f);
+//         return new Vector3(x, 0f, z);
+//     }
+// }

--- a/Assets/Editor/HexGridSnapper.cs
+++ b/Assets/Editor/HexGridSnapper.cs
@@ -1,73 +1,73 @@
-// using UnityEditor;
-// using UnityEngine;
+using UnityEditor;
+using UnityEngine;
 
-// [InitializeOnLoad]
-// public class HexGridSnapper
-// {
-//     private static bool isSnappingEnabled = true; // Snapping is enabled by default
+[InitializeOnLoad]
+public class HexGridSnapper
+{
+    private static bool isSnappingEnabled = true; // Snapping is enabled by default
 
-//     static HexGridSnapper()
-//     {
-//         SceneView.duringSceneGui += OnSceneGUI;
-//     }
+    static HexGridSnapper()
+    {
+        SceneView.duringSceneGui += OnSceneGUI;
+    }
 
-//     // Toggle snapping via menu item
-//     [MenuItem("Tools/Hex Grid Snapping/Toggle Snapping %#h")] // Ctrl + Shift + H
-//     public static void ToggleSnapping()
-//     {
-//         isSnappingEnabled = !isSnappingEnabled;
-//         Debug.Log("Hex Grid Snapping " + (isSnappingEnabled ? "Enabled" : "Disabled"));
-//     }
+    // Toggle snapping via menu item
+    [MenuItem("Tools/Hex Grid Snapping/Toggle Snapping %#h")] // Ctrl + Shift + H
+    public static void ToggleSnapping()
+    {
+        isSnappingEnabled = !isSnappingEnabled;
+        Debug.Log("Hex Grid Snapping " + (isSnappingEnabled ? "Enabled" : "Disabled"));
+    }
 
-//     private static void OnSceneGUI(SceneView sceneView)
-//     {
-//         if (!isSnappingEnabled)
-//             return;
+    private static void OnSceneGUI(SceneView sceneView)
+    {
+        if (!isSnappingEnabled)
+            return;
 
-//         Event e = Event.current;
+        Event e = Event.current;
 
-//         // Check if an object is being moved
-//         if (e.type == EventType.MouseUp && e.button == 0 && Selection.activeTransform != null)
-//         {
-//             foreach (var transform in Selection.transforms)
-//             {
-//                 SnapTransformToHexGrid(transform);
-//             }
-//         }
-//     }
+        // Check if an object is being moved
+        if (e.type == EventType.MouseUp && e.button == 0 && Selection.activeTransform != null)
+        {
+            foreach (var transform in Selection.transforms)
+            {
+                SnapTransformToHexGrid(transform);
+            }
+        }
+    }
 
-//     private static void SnapTransformToHexGrid(Transform transform)
-//     {
-//         // Replace '1f' with your hexagon side length if different
-//         float a = 6.5f; // Side length of your hexagon
-//         float size = a;
+    private static void SnapTransformToHexGrid(Transform transform)
+    {
+        // Replace '1f' with your hexagon side length if different
+        float a = 6.5f; // Side length of your hexagon
+        float size = a;
 
-//         // Calculate hex dimensions
-//         float width = 2f * size;
-//         float height = Mathf.Sqrt(3f) * size;
+        // Calculate hex dimensions
+        float width = 2f * size;
+        float height = Mathf.Sqrt(3f) * size;
 
-//         Vector3 position = transform.position;
+        Vector3 position = transform.position;
 
-//         // Convert world position to hex grid coordinates
-//         float q = (2f / 3f * position.x) / size;
-//         float r = (-1f / 3f * position.x + Mathf.Sqrt(3f) / 3f * position.z) / size;
+        // Convert world position to hex grid coordinates
+        float q = (2f / 3f * position.x) / size;
+        float r = (-1f / 3f * position.x + Mathf.Sqrt(3f) / 3f * position.z) / size;
 
-//         // Round to nearest hex grid coordinate
-//         int qInt = Mathf.RoundToInt(q);
-//         int rInt = Mathf.RoundToInt(r);
+        // Round to nearest hex grid coordinate
+        int qInt = Mathf.RoundToInt(q);
+        int rInt = Mathf.RoundToInt(r);
 
-//         // Convert hex grid coordinates back to world position
-//         Vector3 snappedPosition = HexToWorldPosition(qInt, rInt, size);
+        // Convert hex grid coordinates back to world position
+        Vector3 snappedPosition = HexToWorldPosition(qInt, rInt, size);
 
-//         // Record the change for undo functionality
-//         Undo.RecordObject(transform, "Snap to Hex Grid");
-//         transform.position = snappedPosition;
-//     }
+        // Record the change for undo functionality
+        Undo.RecordObject(transform, "Snap to Hex Grid");
+        transform.position = snappedPosition;
+    }
 
-//     private static Vector3 HexToWorldPosition(int q, int r, float size)
-//     {
-//         float x = size * (3f / 2f) * q;
-//         float z = size * Mathf.Sqrt(3f) * (r + q / 2f);
-//         return new Vector3(x, 0f, z);
-//     }
-// }
+    private static Vector3 HexToWorldPosition(int q, int r, float size)
+    {
+        float x = size * (3f / 2f) * q;
+        float z = size * Mathf.Sqrt(3f) * (r + q / 2f);
+        return new Vector3(x, 0f, z);
+    }
+}

--- a/Assets/Editor/HexGridSnapper.cs.meta
+++ b/Assets/Editor/HexGridSnapper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4a7c926cdd81fc04bbc37c2f90c43934
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -227,6 +227,9 @@ Transform:
   m_Children:
   - {fileID: 363803588}
   - {fileID: 1311341913}
+  - {fileID: 764619313}
+  - {fileID: 1961491158}
+  - {fileID: 1656469854}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &705507993
@@ -323,6 +326,80 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1001 &764619312
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 27.411427
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.8542564
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -62.640816
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (3)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &764619313 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 764619312}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &962195734
 GameObject:
   m_ObjectHideFlags: 0
@@ -526,15 +603,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 8.411427
+      value: 27.411427
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.9
+      value: 2.8542564
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 4.5
+      value: -28.865826
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalRotation.w
@@ -578,6 +655,186 @@ Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
   m_PrefabInstance: {fileID: 1311341912}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1656469853
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 37.161427
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.8542564
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -45.753323
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &1656469854 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 1656469853}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1840913043
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1840913047}
+  - component: {fileID: 1840913046}
+  - component: {fileID: 1840913045}
+  - component: {fileID: 1840913044}
+  m_Layer: 0
+  m_Name: Plane
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!64 &1840913044
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1840913043}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1840913045
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1840913043}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1840913046
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1840913043}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1840913047
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1840913043}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.4954328, y: -28.086052, z: 4.1259575}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1897557167
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -652,6 +909,80 @@ Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
   m_PrefabInstance: {fileID: 1897557167}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1961491157
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 17.661427
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.8542564
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -45.753323
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (4)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &1961491158 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 1961491157}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -661,3 +992,4 @@ SceneRoots:
   - {fileID: 453287303}
   - {fileID: 962195735}
   - {fileID: 1116592874}
+  - {fileID: 1840913047}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -122,13 +122,137 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &1825307
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -19.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -78.80831
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.8660254
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -60
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_Name
+      value: hex_road_A
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+--- !u!4 &1825308 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+  m_PrefabInstance: {fileID: 1825307}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6581729
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 29.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -28.145824
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_Name
+      value: tree_single_A (9)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0129e903876400642b4913d621209c8f, type: 3}
+--- !u!4 &6581730 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+  m_PrefabInstance: {fileID: 6581729}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &20042100
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 453287303}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
       propertyPath: m_LocalPosition.x
@@ -140,7 +264,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -84.43748
+      value: -95.69581
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
       propertyPath: m_LocalRotation.w
@@ -152,7 +276,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
       propertyPath: m_LocalRotation.z
@@ -179,7 +303,669 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
---- !u!1001 &158440188
+--- !u!4 &20042101 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+  m_PrefabInstance: {fileID: 20042100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &56756623
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 9c5f9f3f5a3bdfc448dd0aea18afae2c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9c5f9f3f5a3bdfc448dd0aea18afae2c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9c5f9f3f5a3bdfc448dd0aea18afae2c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -78.80831
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9c5f9f3f5a3bdfc448dd0aea18afae2c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9c5f9f3f5a3bdfc448dd0aea18afae2c, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9c5f9f3f5a3bdfc448dd0aea18afae2c, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9c5f9f3f5a3bdfc448dd0aea18afae2c, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9c5f9f3f5a3bdfc448dd0aea18afae2c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9c5f9f3f5a3bdfc448dd0aea18afae2c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9c5f9f3f5a3bdfc448dd0aea18afae2c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 9c5f9f3f5a3bdfc448dd0aea18afae2c, type: 3}
+      propertyPath: m_Name
+      value: crate_open
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9c5f9f3f5a3bdfc448dd0aea18afae2c, type: 3}
+--- !u!1001 &112801374
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 107.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -95.69581
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.8660254
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_Name
+      value: hex_coast_C (3)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+--- !u!4 &112801375 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+  m_PrefabInstance: {fileID: 112801374}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &116182017
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 87.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -129.4708
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_Name
+      value: hex_water (6)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+--- !u!4 &116182018 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+  m_PrefabInstance: {fileID: 116182017}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &134833497
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 66e47073bf12e9f40a7d8d1b90524559, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 16.572182
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 66e47073bf12e9f40a7d8d1b90524559, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.000014901162
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 66e47073bf12e9f40a7d8d1b90524559, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -50.472374
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 66e47073bf12e9f40a7d8d1b90524559, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 66e47073bf12e9f40a7d8d1b90524559, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 66e47073bf12e9f40a7d8d1b90524559, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 66e47073bf12e9f40a7d8d1b90524559, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 66e47073bf12e9f40a7d8d1b90524559, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 66e47073bf12e9f40a7d8d1b90524559, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 66e47073bf12e9f40a7d8d1b90524559, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 66e47073bf12e9f40a7d8d1b90524559, type: 3}
+      propertyPath: m_Name
+      value: resource_lumber
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 66e47073bf12e9f40a7d8d1b90524559, type: 3}
+--- !u!1001 &164659496
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 5e3b7d6db2f4d6f40beeb5aaa98ca68b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 49.848724
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e3b7d6db2f4d6f40beeb5aaa98ca68b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.00000876188
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e3b7d6db2f4d6f40beeb5aaa98ca68b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -73.92045
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e3b7d6db2f4d6f40beeb5aaa98ca68b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e3b7d6db2f4d6f40beeb5aaa98ca68b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e3b7d6db2f4d6f40beeb5aaa98ca68b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e3b7d6db2f4d6f40beeb5aaa98ca68b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e3b7d6db2f4d6f40beeb5aaa98ca68b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e3b7d6db2f4d6f40beeb5aaa98ca68b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e3b7d6db2f4d6f40beeb5aaa98ca68b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 5e3b7d6db2f4d6f40beeb5aaa98ca68b, type: 3}
+      propertyPath: m_Name
+      value: crate_A_small
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5e3b7d6db2f4d6f40beeb5aaa98ca68b, type: 3}
+--- !u!1001 &169739498
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 68.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -129.4708
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_Name
+      value: hex_water (4)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+--- !u!4 &169739499 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+  m_PrefabInstance: {fileID: 169739498}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &186572040
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 3eb79d0924fd4444189fde5027b40135, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 31.602493
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3eb79d0924fd4444189fde5027b40135, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3eb79d0924fd4444189fde5027b40135, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -71.49391
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3eb79d0924fd4444189fde5027b40135, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3eb79d0924fd4444189fde5027b40135, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3eb79d0924fd4444189fde5027b40135, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3eb79d0924fd4444189fde5027b40135, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3eb79d0924fd4444189fde5027b40135, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3eb79d0924fd4444189fde5027b40135, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3eb79d0924fd4444189fde5027b40135, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 3eb79d0924fd4444189fde5027b40135, type: 3}
+      propertyPath: m_Name
+      value: flag_blue
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3eb79d0924fd4444189fde5027b40135, type: 3}
+--- !u!1001 &206436645
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 39
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -78.80831
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.8660254
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 240
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_Name
+      value: hex_road_M (3)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+--- !u!4 &206436646 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+  m_PrefabInstance: {fileID: 206436645}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &238420128
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 01aab845c1a70ec498cee5e39b632e6e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20.53326
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 01aab845c1a70ec498cee5e39b632e6e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.00000029802322
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 01aab845c1a70ec498cee5e39b632e6e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -44.13231
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 01aab845c1a70ec498cee5e39b632e6e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 01aab845c1a70ec498cee5e39b632e6e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 01aab845c1a70ec498cee5e39b632e6e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 01aab845c1a70ec498cee5e39b632e6e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 01aab845c1a70ec498cee5e39b632e6e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 01aab845c1a70ec498cee5e39b632e6e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 01aab845c1a70ec498cee5e39b632e6e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 01aab845c1a70ec498cee5e39b632e6e, type: 3}
+      propertyPath: m_Name
+      value: wheelbarrow
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 01aab845c1a70ec498cee5e39b632e6e, type: 3}
+--- !u!1001 &244528934
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 96151b6f6b77dd34bb2a4696a5afe9a6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 29.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 96151b6f6b77dd34bb2a4696a5afe9a6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 96151b6f6b77dd34bb2a4696a5afe9a6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -95.69581
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 96151b6f6b77dd34bb2a4696a5afe9a6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 96151b6f6b77dd34bb2a4696a5afe9a6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 96151b6f6b77dd34bb2a4696a5afe9a6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 96151b6f6b77dd34bb2a4696a5afe9a6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 96151b6f6b77dd34bb2a4696a5afe9a6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 96151b6f6b77dd34bb2a4696a5afe9a6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 96151b6f6b77dd34bb2a4696a5afe9a6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 96151b6f6b77dd34bb2a4696a5afe9a6, type: 3}
+      propertyPath: m_Name
+      value: waterplant_B
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 96151b6f6b77dd34bb2a4696a5afe9a6, type: 3}
+--- !u!4 &244528935 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 96151b6f6b77dd34bb2a4696a5afe9a6, type: 3}
+  m_PrefabInstance: {fileID: 244528934}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &258689471
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: c0383a69bb8bc834d8d200523738c9b3, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c0383a69bb8bc834d8d200523738c9b3, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c0383a69bb8bc834d8d200523738c9b3, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -22.516659
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c0383a69bb8bc834d8d200523738c9b3, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c0383a69bb8bc834d8d200523738c9b3, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c0383a69bb8bc834d8d200523738c9b3, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c0383a69bb8bc834d8d200523738c9b3, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c0383a69bb8bc834d8d200523738c9b3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c0383a69bb8bc834d8d200523738c9b3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c0383a69bb8bc834d8d200523738c9b3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: c0383a69bb8bc834d8d200523738c9b3, type: 3}
+      propertyPath: m_Name
+      value: trees_B_cut
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c0383a69bb8bc834d8d200523738c9b3, type: 3}
+--- !u!4 &258689472 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: c0383a69bb8bc834d8d200523738c9b3, type: 3}
+  m_PrefabInstance: {fileID: 258689471}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &283822962
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -201,7 +987,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 48.75
+      value: 87.75
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.y
@@ -209,7 +995,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -61.920815
+      value: -28.145824
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalRotation.w
@@ -241,17 +1027,339 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_Name
-      value: hex_grass (5)
+      value: hex_grass (18)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
---- !u!4 &158440189 stripped
+--- !u!4 &283822963 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
-  m_PrefabInstance: {fileID: 158440188}
+  m_PrefabInstance: {fileID: 283822962}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &314588137
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: b6b947703679db448b5160de810dc90f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b6b947703679db448b5160de810dc90f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b6b947703679db448b5160de810dc90f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -61.920815
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b6b947703679db448b5160de810dc90f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b6b947703679db448b5160de810dc90f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b6b947703679db448b5160de810dc90f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b6b947703679db448b5160de810dc90f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b6b947703679db448b5160de810dc90f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b6b947703679db448b5160de810dc90f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b6b947703679db448b5160de810dc90f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: b6b947703679db448b5160de810dc90f, type: 3}
+      propertyPath: m_Name
+      value: hex_road_B
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b6b947703679db448b5160de810dc90f, type: 3}
+--- !u!4 &314588138 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: b6b947703679db448b5160de810dc90f, type: 3}
+  m_PrefabInstance: {fileID: 314588137}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &320315493
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -11.258329
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_Name
+      value: tree_single_A (5)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0129e903876400642b4913d621209c8f, type: 3}
+--- !u!4 &320315494 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+  m_PrefabInstance: {fileID: 320315493}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &333590959
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -29.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -95.69581
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.8660254
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -60
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_Name
+      value: hex_road_A (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+--- !u!4 &333590960 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+  m_PrefabInstance: {fileID: 333590959}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &348679959
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -78.80831
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.8660254
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -60
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_Name
+      value: hex_road_M (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+--- !u!4 &348679960 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+  m_PrefabInstance: {fileID: 348679959}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &361748269
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 29.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.629165
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (32)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &361748270 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 361748269}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &363803587
 PrefabInstance:
@@ -275,15 +1383,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -11.588573
+      value: 9.75
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.8542564
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 4.9091635
+      value: -28.145824
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalRotation.w
@@ -327,6 +1435,204 @@ Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
   m_PrefabInstance: {fileID: 363803587}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &382901271
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -16.887495
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_Name
+      value: tree_single_A (7)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0129e903876400642b4913d621209c8f, type: 3}
+--- !u!4 &382901272 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+  m_PrefabInstance: {fileID: 382901271}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &388382134
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 630c98301ebec7e4ab99e4d0ac6ea8f0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 68.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 630c98301ebec7e4ab99e4d0ac6ea8f0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 630c98301ebec7e4ab99e4d0ac6ea8f0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -28.145824
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 630c98301ebec7e4ab99e4d0ac6ea8f0, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 630c98301ebec7e4ab99e4d0ac6ea8f0, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 630c98301ebec7e4ab99e4d0ac6ea8f0, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 630c98301ebec7e4ab99e4d0ac6ea8f0, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 630c98301ebec7e4ab99e4d0ac6ea8f0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 630c98301ebec7e4ab99e4d0ac6ea8f0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 630c98301ebec7e4ab99e4d0ac6ea8f0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 630c98301ebec7e4ab99e4d0ac6ea8f0, type: 3}
+      propertyPath: m_Name
+      value: mountain_A_grass
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 630c98301ebec7e4ab99e4d0ac6ea8f0, type: 3}
+--- !u!4 &388382135 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 630c98301ebec7e4ab99e4d0ac6ea8f0, type: 3}
+  m_PrefabInstance: {fileID: 388382134}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &401258494
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 68.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.629165
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (34)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &401258495 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 401258494}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &453287302
 GameObject:
   m_ObjectHideFlags: 0
@@ -358,18 +1664,679 @@ Transform:
   m_Children:
   - {fileID: 363803588}
   - {fileID: 1311341913}
-  - {fileID: 764619313}
-  - {fileID: 1961491158}
-  - {fileID: 1656469854}
-  - {fileID: 158440189}
   - {fileID: 1773018901}
   - {fileID: 684809487}
-  - {fileID: 1746552037}
-  - {fileID: 1669359595}
-  - {fileID: 1823846778}
+  - {fileID: 746020377}
+  - {fileID: 739550635}
+  - {fileID: 1589002719}
+  - {fileID: 283822963}
+  - {fileID: 1977722982}
+  - {fileID: 879281934}
+  - {fileID: 1417892412}
+  - {fileID: 1542964009}
+  - {fileID: 1975947733}
+  - {fileID: 983598447}
+  - {fileID: 1317524412}
+  - {fileID: 1289029696}
+  - {fileID: 1432909104}
+  - {fileID: 1794364442}
+  - {fileID: 808059955}
+  - {fileID: 863469965}
+  - {fileID: 901999512}
+  - {fileID: 1052730058}
+  - {fileID: 846603550}
+  - {fileID: 797255406}
+  - {fileID: 1211656673}
+  - {fileID: 602268687}
+  - {fileID: 1949116521}
+  - {fileID: 918174727}
+  - {fileID: 361748270}
+  - {fileID: 1660337455}
+  - {fileID: 401258495}
+  - {fileID: 1839843318}
+  - {fileID: 633664141}
+  - {fileID: 1077617647}
   - {fileID: 1106259831}
+  - {fileID: 20042101}
+  - {fileID: 764100790}
+  - {fileID: 1298600413}
+  - {fileID: 169739499}
+  - {fileID: 1470298114}
+  - {fileID: 116182018}
+  - {fileID: 1574835936}
+  - {fileID: 623657552}
+  - {fileID: 912768705}
+  - {fileID: 669194481}
+  - {fileID: 888103672}
+  - {fileID: 2114155303}
+  - {fileID: 870176649}
+  - {fileID: 1438686199}
+  - {fileID: 112801375}
+  - {fileID: 590905587}
+  - {fileID: 314588138}
+  - {fileID: 1906798634}
+  - {fileID: 560955683}
+  - {fileID: 1988683828}
+  - {fileID: 206436646}
+  - {fileID: 1706472908}
+  - {fileID: 348679960}
+  - {fileID: 1096082940}
+  - {fileID: 1127865211}
+  - {fileID: 2102874054}
+  - {fileID: 1825308}
+  - {fileID: 333590960}
+  - {fileID: 1259252687}
+  - {fileID: 1255599354}
+  - {fileID: 825514956}
+  - {fileID: 1309038332}
+  - {fileID: 671805092}
+  - {fileID: 2113496595}
+  - {fileID: 810360616}
+  - {fileID: 870729723}
+  - {fileID: 501012653}
+  - {fileID: 1407861344}
+  - {fileID: 1373261400}
+  - {fileID: 320315494}
+  - {fileID: 817875191}
+  - {fileID: 382901272}
+  - {fileID: 1909877540}
+  - {fileID: 6581730}
+  - {fileID: 388382135}
+  - {fileID: 1513597573}
+  - {fileID: 699075868}
+  - {fileID: 1458059173}
+  - {fileID: 1791252076}
+  - {fileID: 2010261263}
+  - {fileID: 258689472}
+  - {fileID: 244528935}
+  - {fileID: 1491643500}
+  - {fileID: 1764896355}
+  - {fileID: 2047835870}
+  - {fileID: 1140999678}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &501012652
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_Name
+      value: tree_single_A (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0129e903876400642b4913d621209c8f, type: 3}
+--- !u!4 &501012653 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+  m_PrefabInstance: {fileID: 501012652}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &524367048
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 962195735}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: c7acbf649a869a7409971a645ecb8737, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 27.855013
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c7acbf649a869a7409971a645ecb8737, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.4338722
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c7acbf649a869a7409971a645ecb8737, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -86.485725
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c7acbf649a869a7409971a645ecb8737, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9540479
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c7acbf649a869a7409971a645ecb8737, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.000000077717075
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c7acbf649a869a7409971a645ecb8737, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.29965407
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c7acbf649a869a7409971a645ecb8737, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.000000024409921
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c7acbf649a869a7409971a645ecb8737, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c7acbf649a869a7409971a645ecb8737, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 34.874
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c7acbf649a869a7409971a645ecb8737, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: c7acbf649a869a7409971a645ecb8737, type: 3}
+      propertyPath: m_Name
+      value: building_blacksmith_blue
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c7acbf649a869a7409971a645ecb8737, type: 3}
+--- !u!4 &524367049 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: c7acbf649a869a7409971a645ecb8737, type: 3}
+  m_PrefabInstance: {fileID: 524367048}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &560955682
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -45.03332
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.8660254
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_Name
+      value: hex_road_M
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+--- !u!4 &560955683 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+  m_PrefabInstance: {fileID: 560955682}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &590905586
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 3bf99af0f2ffe464f9ce86b3678d2b78, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 48.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3bf99af0f2ffe464f9ce86b3678d2b78, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3bf99af0f2ffe464f9ce86b3678d2b78, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -95.69581
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3bf99af0f2ffe464f9ce86b3678d2b78, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3bf99af0f2ffe464f9ce86b3678d2b78, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3bf99af0f2ffe464f9ce86b3678d2b78, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3bf99af0f2ffe464f9ce86b3678d2b78, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3bf99af0f2ffe464f9ce86b3678d2b78, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3bf99af0f2ffe464f9ce86b3678d2b78, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3bf99af0f2ffe464f9ce86b3678d2b78, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 3bf99af0f2ffe464f9ce86b3678d2b78, type: 3}
+      propertyPath: m_Name
+      value: hex_coast_D
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3bf99af0f2ffe464f9ce86b3678d2b78, type: 3}
+--- !u!4 &590905587 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 3bf99af0f2ffe464f9ce86b3678d2b78, type: 3}
+  m_PrefabInstance: {fileID: 590905586}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &602268686
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -28.145824
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (37)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &602268687 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 602268686}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &623657551
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 48.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -129.4708
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_Name
+      value: hex_water (7)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+--- !u!4 &623657552 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+  m_PrefabInstance: {fileID: 623657551}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &633664140
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -95.69581
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (16)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &633664141 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 633664140}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &669194480
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 2d266fc090e5e3548a64ca957f5e0e99, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 29.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2d266fc090e5e3548a64ca957f5e0e99, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2d266fc090e5e3548a64ca957f5e0e99, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -61.920815
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2d266fc090e5e3548a64ca957f5e0e99, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2d266fc090e5e3548a64ca957f5e0e99, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2d266fc090e5e3548a64ca957f5e0e99, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2d266fc090e5e3548a64ca957f5e0e99, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2d266fc090e5e3548a64ca957f5e0e99, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2d266fc090e5e3548a64ca957f5e0e99, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2d266fc090e5e3548a64ca957f5e0e99, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 2d266fc090e5e3548a64ca957f5e0e99, type: 3}
+      propertyPath: m_Name
+      value: hex_road_L
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2d266fc090e5e3548a64ca957f5e0e99, type: 3}
+--- !u!4 &669194481 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 2d266fc090e5e3548a64ca957f5e0e99, type: 3}
+  m_PrefabInstance: {fileID: 669194480}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &671805091
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.629165
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_Name
+      value: trees_A_medium (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+--- !u!4 &671805092 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+  m_PrefabInstance: {fileID: 671805091}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &684809486
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -443,6 +2410,68 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
   m_PrefabInstance: {fileID: 684809486}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &699075867
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: f2967d7ebba4d4a4eae9e6932d0fd8a0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 58.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f2967d7ebba4d4a4eae9e6932d0fd8a0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f2967d7ebba4d4a4eae9e6932d0fd8a0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -45.03332
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f2967d7ebba4d4a4eae9e6932d0fd8a0, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f2967d7ebba4d4a4eae9e6932d0fd8a0, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f2967d7ebba4d4a4eae9e6932d0fd8a0, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f2967d7ebba4d4a4eae9e6932d0fd8a0, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f2967d7ebba4d4a4eae9e6932d0fd8a0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f2967d7ebba4d4a4eae9e6932d0fd8a0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f2967d7ebba4d4a4eae9e6932d0fd8a0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: f2967d7ebba4d4a4eae9e6932d0fd8a0, type: 3}
+      propertyPath: m_Name
+      value: hill_single_B
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f2967d7ebba4d4a4eae9e6932d0fd8a0, type: 3}
+--- !u!4 &699075868 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: f2967d7ebba4d4a4eae9e6932d0fd8a0, type: 3}
+  m_PrefabInstance: {fileID: 699075867}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &705507993
 GameObject:
@@ -538,7 +2567,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!1001 &764619312
+--- !u!1001 &739550634
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -560,7 +2589,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 29.25
+      value: 87.75
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.y
@@ -600,19 +2629,365 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_Name
-      value: hex_grass (3)
+      value: hex_grass (13)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
---- !u!4 &764619313 stripped
+--- !u!4 &739550635 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
-  m_PrefabInstance: {fileID: 764619312}
+  m_PrefabInstance: {fileID: 739550634}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &912768704
+--- !u!1001 &746020376
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 68.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -28.145824
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (8)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &746020377 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 746020376}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &764100789
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 87.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -95.69581
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_Name
+      value: hex_water (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+--- !u!4 &764100790 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+  m_PrefabInstance: {fileID: 764100789}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &797255405
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -19.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -45.03332
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (36)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &797255406 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 797255405}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &808059954
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -112.5833
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (24)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &808059955 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 808059954}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &810360615
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -22.516659
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_Name
+      value: tree_single_A
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0129e903876400642b4913d621209c8f, type: 3}
+--- !u!4 &810360616 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+  m_PrefabInstance: {fileID: 810360615}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &811462061
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -620,9 +2995,672 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: c02d6af7126af794797d30d3746f1b32, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 58.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c02d6af7126af794797d30d3746f1b32, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c02d6af7126af794797d30d3746f1b32, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -78.80831
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c02d6af7126af794797d30d3746f1b32, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c02d6af7126af794797d30d3746f1b32, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c02d6af7126af794797d30d3746f1b32, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c02d6af7126af794797d30d3746f1b32, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c02d6af7126af794797d30d3746f1b32, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c02d6af7126af794797d30d3746f1b32, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: c02d6af7126af794797d30d3746f1b32, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: c02d6af7126af794797d30d3746f1b32, type: 3}
+      propertyPath: m_Name
+      value: bucket_water
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c02d6af7126af794797d30d3746f1b32, type: 3}
+--- !u!1001 &817875190
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 29.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -16.887495
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_Name
+      value: tree_single_A (6)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0129e903876400642b4913d621209c8f, type: 3}
+--- !u!4 &817875191 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+  m_PrefabInstance: {fileID: 817875190}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &825514955
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 39
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -11.258329
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_Name
+      value: trees_A_medium
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+--- !u!4 &825514956 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+  m_PrefabInstance: {fileID: 825514955}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &846603549
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -29.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -61.920815
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (28)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &846603550 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 846603549}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &863469964
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -129.4708
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (25)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &863469965 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 863469964}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &870176648
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 97.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -78.80831
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.8660254
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 240
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_Name
+      value: hex_coast_C (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+--- !u!4 &870176649 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+  m_PrefabInstance: {fileID: 870176648}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &870729722
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -5.629165
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_Name
+      value: tree_single_A (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0129e903876400642b4913d621209c8f, type: 3}
+--- !u!4 &870729723 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+  m_PrefabInstance: {fileID: 870729722}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &879281933
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 97.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -11.258329
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (20)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &879281934 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 879281933}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &888103671
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 4282af7996e945e4fb8d356288d61cb5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 58.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4282af7996e945e4fb8d356288d61cb5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4282af7996e945e4fb8d356288d61cb5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -78.80831
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4282af7996e945e4fb8d356288d61cb5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4282af7996e945e4fb8d356288d61cb5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4282af7996e945e4fb8d356288d61cb5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4282af7996e945e4fb8d356288d61cb5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4282af7996e945e4fb8d356288d61cb5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4282af7996e945e4fb8d356288d61cb5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4282af7996e945e4fb8d356288d61cb5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 4282af7996e945e4fb8d356288d61cb5, type: 3}
+      propertyPath: m_Name
+      value: hex_coast_B
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4282af7996e945e4fb8d356288d61cb5, type: 3}
+--- !u!4 &888103672 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 4282af7996e945e4fb8d356288d61cb5, type: 3}
+  m_PrefabInstance: {fileID: 888103671}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &901999511
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -112.5833
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (26)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &901999512 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 901999511}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &912768704
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
     - target: {fileID: -8679921383154817045, guid: 5188be284f4561247a2983d4660c8eac, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 78
+      value: 68.25
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5188be284f4561247a2983d4660c8eac, type: 3}
       propertyPath: m_LocalPosition.y
@@ -630,7 +3668,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5188be284f4561247a2983d4660c8eac, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -67.54998
+      value: -61.920815
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5188be284f4561247a2983d4660c8eac, type: 3}
       propertyPath: m_LocalRotation.w
@@ -638,7 +3676,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5188be284f4561247a2983d4660c8eac, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5188be284f4561247a2983d4660c8eac, type: 3}
       propertyPath: m_LocalRotation.y
@@ -646,7 +3684,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5188be284f4561247a2983d4660c8eac, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5188be284f4561247a2983d4660c8eac, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -669,6 +3707,85 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5188be284f4561247a2983d4660c8eac, type: 3}
+--- !u!4 &912768705 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 5188be284f4561247a2983d4660c8eac, type: 3}
+  m_PrefabInstance: {fileID: 912768704}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &918174726
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 48.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.629165
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (31)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &918174727 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 918174726}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &962195734
 GameObject:
   m_ObjectHideFlags: 0
@@ -699,6 +3816,12 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1897557168}
+  - {fileID: 1807892385}
+  - {fileID: 2030174731}
+  - {fileID: 1798522771}
+  - {fileID: 1341522040}
+  - {fileID: 1479506307}
+  - {fileID: 524367049}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &963194225
@@ -793,6 +3916,290 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &983598446
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 58.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -11.258329
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (9)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &983598447 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 983598446}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1052730057
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -95.69581
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (27)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &1052730058 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 1052730057}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1077617646
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -78.80831
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (17)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &1077617647 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 1077617646}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1096082939
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 24f11d0a90844944388d04fcfb6f6b47, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 117
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 24f11d0a90844944388d04fcfb6f6b47, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 24f11d0a90844944388d04fcfb6f6b47, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -78.80831
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 24f11d0a90844944388d04fcfb6f6b47, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.49999994
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 24f11d0a90844944388d04fcfb6f6b47, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 24f11d0a90844944388d04fcfb6f6b47, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.86602545
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 24f11d0a90844944388d04fcfb6f6b47, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 24f11d0a90844944388d04fcfb6f6b47, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 24f11d0a90844944388d04fcfb6f6b47, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -120
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 24f11d0a90844944388d04fcfb6f6b47, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 24f11d0a90844944388d04fcfb6f6b47, type: 3}
+      propertyPath: m_Name
+      value: hex_coast_E
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 24f11d0a90844944388d04fcfb6f6b47, type: 3}
+--- !u!4 &1096082940 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 24f11d0a90844944388d04fcfb6f6b47, type: 3}
+  m_PrefabInstance: {fileID: 1096082939}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1106259830
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -865,7 +4272,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 9.75
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
       propertyPath: m_LocalPosition.y
@@ -873,11 +4280,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 5.629165
+      value: -56.29165
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.64838004
+      value: -0.23161267
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
       propertyPath: m_LocalRotation.x
@@ -885,7 +4292,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.76131684
+      value: 0.9728081
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
       propertyPath: m_LocalRotation.z
@@ -897,7 +4304,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: -99.161
+      value: 206.784
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
@@ -912,6 +4319,583 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
+--- !u!1001 &1127865210
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 9e9a4f6e5119ce64c8a2668ed4605090, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 29.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9e9a4f6e5119ce64c8a2668ed4605090, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9e9a4f6e5119ce64c8a2668ed4605090, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -129.4708
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9e9a4f6e5119ce64c8a2668ed4605090, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.49999994
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9e9a4f6e5119ce64c8a2668ed4605090, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9e9a4f6e5119ce64c8a2668ed4605090, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.86602545
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9e9a4f6e5119ce64c8a2668ed4605090, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9e9a4f6e5119ce64c8a2668ed4605090, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9e9a4f6e5119ce64c8a2668ed4605090, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9e9a4f6e5119ce64c8a2668ed4605090, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 9e9a4f6e5119ce64c8a2668ed4605090, type: 3}
+      propertyPath: m_Name
+      value: hex_coast_A
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9e9a4f6e5119ce64c8a2668ed4605090, type: 3}
+--- !u!4 &1127865211 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 9e9a4f6e5119ce64c8a2668ed4605090, type: 3}
+  m_PrefabInstance: {fileID: 1127865210}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1140999677
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: ed712fc97fe7f3f4f93f9e784df405c5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ed712fc97fe7f3f4f93f9e784df405c5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ed712fc97fe7f3f4f93f9e784df405c5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -112.5833
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ed712fc97fe7f3f4f93f9e784df405c5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ed712fc97fe7f3f4f93f9e784df405c5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ed712fc97fe7f3f4f93f9e784df405c5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ed712fc97fe7f3f4f93f9e784df405c5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ed712fc97fe7f3f4f93f9e784df405c5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ed712fc97fe7f3f4f93f9e784df405c5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ed712fc97fe7f3f4f93f9e784df405c5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: ed712fc97fe7f3f4f93f9e784df405c5, type: 3}
+      propertyPath: m_Name
+      value: rock_single_D
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ed712fc97fe7f3f4f93f9e784df405c5, type: 3}
+--- !u!4 &1140999678 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: ed712fc97fe7f3f4f93f9e784df405c5, type: 3}
+  m_PrefabInstance: {fileID: 1140999677}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1191176550
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 5e59bfc419307f7468f439aa91932e8c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e59bfc419307f7468f439aa91932e8c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e59bfc419307f7468f439aa91932e8c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -78.80831
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e59bfc419307f7468f439aa91932e8c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e59bfc419307f7468f439aa91932e8c, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e59bfc419307f7468f439aa91932e8c, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e59bfc419307f7468f439aa91932e8c, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e59bfc419307f7468f439aa91932e8c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e59bfc419307f7468f439aa91932e8c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5e59bfc419307f7468f439aa91932e8c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 5e59bfc419307f7468f439aa91932e8c, type: 3}
+      propertyPath: m_Name
+      value: pallet
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5e59bfc419307f7468f439aa91932e8c, type: 3}
+--- !u!1001 &1211656672
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -28.145824
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (29)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &1211656673 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 1211656672}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1255599353
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -48.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -129.4708
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.8660254
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -60
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_Name
+      value: hex_road_A (3)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+--- !u!4 &1255599354 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+  m_PrefabInstance: {fileID: 1255599353}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1259252686
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -39
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -112.5833
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.8660254
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -60
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_Name
+      value: hex_road_A (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+--- !u!4 &1259252687 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+  m_PrefabInstance: {fileID: 1259252686}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1289029695
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -11.258329
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (11)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &1289029696 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 1289029695}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1298600412
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 78
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -112.5833
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_Name
+      value: hex_water (3)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+--- !u!4 &1298600413 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+  m_PrefabInstance: {fileID: 1298600412}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1309038331
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 29.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.629165
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_Name
+      value: trees_A_medium (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+--- !u!4 &1309038332 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+  m_PrefabInstance: {fileID: 1309038331}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1311341912
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -986,64 +4970,7 @@ Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
   m_PrefabInstance: {fileID: 1311341912}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1574835935
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 58.5
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -101.324974
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.00000008146034
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
-      propertyPath: m_Name
-      value: hex_water (1)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
---- !u!1001 &1656469853
+--- !u!1001 &1317524411
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -1066,6 +4993,340 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.x
       value: 39
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -11.258329
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (10)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &1317524412 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 1317524411}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1341522039
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 962195735}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 9978d9261635a5842bd20986a2436686, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 27.855013
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9978d9261635a5842bd20986a2436686, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.4338722
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9978d9261635a5842bd20986a2436686, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -52.71073
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9978d9261635a5842bd20986a2436686, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9978d9261635a5842bd20986a2436686, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9978d9261635a5842bd20986a2436686, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9978d9261635a5842bd20986a2436686, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9978d9261635a5842bd20986a2436686, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9978d9261635a5842bd20986a2436686, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9978d9261635a5842bd20986a2436686, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 9978d9261635a5842bd20986a2436686, type: 3}
+      propertyPath: m_Name
+      value: building_lumbermill_blue
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9978d9261635a5842bd20986a2436686, type: 3}
+--- !u!4 &1341522040 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 9978d9261635a5842bd20986a2436686, type: 3}
+  m_PrefabInstance: {fileID: 1341522039}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1373261399
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 39
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -22.516659
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_Name
+      value: tree_single_A (4)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0129e903876400642b4913d621209c8f, type: 3}
+--- !u!4 &1373261400 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+  m_PrefabInstance: {fileID: 1373261399}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1407861343
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 29.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -5.629165
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_Name
+      value: tree_single_A (3)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0129e903876400642b4913d621209c8f, type: 3}
+--- !u!4 &1407861344 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+  m_PrefabInstance: {fileID: 1407861343}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1417892411
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 107.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -28.145824
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (21)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &1417892412 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 1417892411}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1432909103
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.y
@@ -1105,19 +5366,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_Name
-      value: hex_grass (2)
+      value: hex_grass (12)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
---- !u!4 &1656469854 stripped
+--- !u!4 &1432909104 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
-  m_PrefabInstance: {fileID: 1656469853}
+  m_PrefabInstance: {fileID: 1432909103}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1669359594
+--- !u!1001 &1438686198
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -1125,61 +5386,502 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 453287303}
     m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 107.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -95.69581
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.8660254
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_Name
+      value: hex_coast_C (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+--- !u!4 &1438686199 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+  m_PrefabInstance: {fileID: 1438686198}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1458059172
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: d9ff05fe3c0e5e7428b5007917d4d64c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 58.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d9ff05fe3c0e5e7428b5007917d4d64c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d9ff05fe3c0e5e7428b5007917d4d64c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d9ff05fe3c0e5e7428b5007917d4d64c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d9ff05fe3c0e5e7428b5007917d4d64c, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d9ff05fe3c0e5e7428b5007917d4d64c, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d9ff05fe3c0e5e7428b5007917d4d64c, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d9ff05fe3c0e5e7428b5007917d4d64c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d9ff05fe3c0e5e7428b5007917d4d64c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d9ff05fe3c0e5e7428b5007917d4d64c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: d9ff05fe3c0e5e7428b5007917d4d64c, type: 3}
+      propertyPath: m_Name
+      value: cloud_big
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d9ff05fe3c0e5e7428b5007917d4d64c, type: 3}
+--- !u!4 &1458059173 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: d9ff05fe3c0e5e7428b5007917d4d64c, type: 3}
+  m_PrefabInstance: {fileID: 1458059172}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1470298113
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 97.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -112.5833
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_Name
+      value: hex_water (5)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+--- !u!4 &1470298114 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+  m_PrefabInstance: {fileID: 1470298113}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1479506306
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 962195735}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: be4145d318b19ca46b8e81c1075bdd82, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 47.35501
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: be4145d318b19ca46b8e81c1075bdd82, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.4338722
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: be4145d318b19ca46b8e81c1075bdd82, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -86.485725
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: be4145d318b19ca46b8e81c1075bdd82, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.9706317
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: be4145d318b19ca46b8e81c1075bdd82, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.00000007906801
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: be4145d318b19ca46b8e81c1075bdd82, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.24057052
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: be4145d318b19ca46b8e81c1075bdd82, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.000000019596966
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: be4145d318b19ca46b8e81c1075bdd82, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: be4145d318b19ca46b8e81c1075bdd82, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 332.16
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: be4145d318b19ca46b8e81c1075bdd82, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: be4145d318b19ca46b8e81c1075bdd82, type: 3}
+      propertyPath: m_Name
+      value: building_home_B_blue
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: be4145d318b19ca46b8e81c1075bdd82, type: 3}
+--- !u!4 &1479506307 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: be4145d318b19ca46b8e81c1075bdd82, type: 3}
+  m_PrefabInstance: {fileID: 1479506306}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1491643499
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: ea2f50eec31079e4f8d9b912cee0c3ce, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 29.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea2f50eec31079e4f8d9b912cee0c3ce, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea2f50eec31079e4f8d9b912cee0c3ce, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -95.69581
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea2f50eec31079e4f8d9b912cee0c3ce, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea2f50eec31079e4f8d9b912cee0c3ce, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea2f50eec31079e4f8d9b912cee0c3ce, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea2f50eec31079e4f8d9b912cee0c3ce, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea2f50eec31079e4f8d9b912cee0c3ce, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea2f50eec31079e4f8d9b912cee0c3ce, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea2f50eec31079e4f8d9b912cee0c3ce, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: ea2f50eec31079e4f8d9b912cee0c3ce, type: 3}
+      propertyPath: m_Name
+      value: waterplant_C
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ea2f50eec31079e4f8d9b912cee0c3ce, type: 3}
+--- !u!4 &1491643500 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: ea2f50eec31079e4f8d9b912cee0c3ce, type: 3}
+  m_PrefabInstance: {fileID: 1491643499}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1513597572
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: b4fe099feba79634abdc148b8f98d4c9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 87.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b4fe099feba79634abdc148b8f98d4c9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b4fe099feba79634abdc148b8f98d4c9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -28.145824
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b4fe099feba79634abdc148b8f98d4c9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b4fe099feba79634abdc148b8f98d4c9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b4fe099feba79634abdc148b8f98d4c9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b4fe099feba79634abdc148b8f98d4c9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b4fe099feba79634abdc148b8f98d4c9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b4fe099feba79634abdc148b8f98d4c9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b4fe099feba79634abdc148b8f98d4c9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: b4fe099feba79634abdc148b8f98d4c9, type: 3}
+      propertyPath: m_Name
+      value: mountain_B_grass_trees
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b4fe099feba79634abdc148b8f98d4c9, type: 3}
+--- !u!4 &1513597573 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: b4fe099feba79634abdc148b8f98d4c9, type: 3}
+  m_PrefabInstance: {fileID: 1513597572}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1542964008
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 117
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -45.03332
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (22)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &1542964009 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 1542964008}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1552792779
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: e32add1fdf7b20b4ba5bfcd44c7d607f, type: 3}
       propertyPath: m_LocalPosition.x
       value: 19.5
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: e32add1fdf7b20b4ba5bfcd44c7d607f, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: e32add1fdf7b20b4ba5bfcd44c7d607f, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -78.80831
+      value: -56.29165
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: e32add1fdf7b20b4ba5bfcd44c7d607f, type: 3}
       propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e32add1fdf7b20b4ba5bfcd44c7d607f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e32add1fdf7b20b4ba5bfcd44c7d607f, type: 3}
+      propertyPath: m_LocalRotation.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.00000008146034
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: e32add1fdf7b20b4ba5bfcd44c7d607f, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: e32add1fdf7b20b4ba5bfcd44c7d607f, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: e32add1fdf7b20b4ba5bfcd44c7d607f, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: 180
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: e32add1fdf7b20b4ba5bfcd44c7d607f, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: 919132149155446097, guid: e32add1fdf7b20b4ba5bfcd44c7d607f, type: 3}
       propertyPath: m_Name
-      value: hex_grass_bottom (1)
+      value: crate_long_A
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
---- !u!4 &1669359595 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
-  m_PrefabInstance: {fileID: 1669359594}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1746552036
+  m_SourcePrefab: {fileID: 100100000, guid: e32add1fdf7b20b4ba5bfcd44c7d607f, type: 3}
+--- !u!1001 &1574835935
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -1187,59 +5889,331 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 453287303}
     m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 39
+      value: 58.5
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -78.80831
+      value: -112.5833
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0.00000008146034
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: 919132149155446097, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
       propertyPath: m_Name
-      value: hex_grass_bottom
+      value: hex_water (1)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
---- !u!4 &1746552037 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+--- !u!4 &1574835936 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
-  m_PrefabInstance: {fileID: 1746552036}
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+  m_PrefabInstance: {fileID: 1574835935}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1589002718
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 97.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -45.03332
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (14)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &1589002719 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 1589002718}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1660337454
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.629165
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (33)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &1660337455 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 1660337454}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1706472907
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 48.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -61.920815
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_Name
+      value: hex_road_M (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+--- !u!4 &1706472908 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+  m_PrefabInstance: {fileID: 1706472907}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1764896354
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 29.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -95.69581
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+      propertyPath: m_Name
+      value: waterplant_A
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+--- !u!4 &1764896355 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+  m_PrefabInstance: {fileID: 1764896354}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1773018900
 PrefabInstance:
@@ -1315,7 +6289,7 @@ Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
   m_PrefabInstance: {fileID: 1773018900}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1823846777
+--- !u!1001 &1791252075
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -1323,241 +6297,61 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 453287303}
     m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 9.75
+      value: 39
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -61.920815
+      value: -112.5833
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.49999994
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.00000008146034
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
-      propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.86602545
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: 120
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+    - target: {fileID: 919132149155446097, guid: 005e5339625fc4843a100487e33cff94, type: 3}
       propertyPath: m_Name
-      value: hex_grass_bottom (2)
+      value: hex_coast_C (1)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
---- !u!4 &1823846778 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+--- !u!4 &1791252076 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
-  m_PrefabInstance: {fileID: 1823846777}
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+  m_PrefabInstance: {fileID: 1791252075}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1840913043
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1840913047}
-  - component: {fileID: 1840913046}
-  - component: {fileID: 1840913045}
-  - component: {fileID: 1840913044}
-  m_Layer: 0
-  m_Name: Plane
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!64 &1840913044
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1840913043}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 5
-  m_Convex: 0
-  m_CookingOptions: 30
-  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &1840913045
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1840913043}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &1840913046
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1840913043}
-  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &1840913047
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1840913043}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.4954328, y: -28.086052, z: 4.1259575}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1897557167
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 962195735}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -1.3949871
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.4338722
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -2.0482464
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.83849025
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.00000006830381
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.5449167
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.000000044389108
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 66.038
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
-      propertyPath: m_Name
-      value: building_archeryrange_blue
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
---- !u!4 &1897557168 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
-  m_PrefabInstance: {fileID: 1897557167}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1961491157
+--- !u!1001 &1794364441
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -1579,7 +6373,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 19.5
+      value: 29.25
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.y
@@ -1587,7 +6381,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -45.03332
+      value: -95.69581
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalRotation.w
@@ -1619,17 +6413,1126 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_Name
-      value: hex_grass (4)
+      value: hex_grass (15)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
---- !u!4 &1961491158 stripped
+--- !u!4 &1794364442 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
-  m_PrefabInstance: {fileID: 1961491157}
+  m_PrefabInstance: {fileID: 1794364441}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1798522770
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 962195735}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0cbf32b52191f484cbaad25790820316, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.3949871
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0cbf32b52191f484cbaad25790820316, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.4338722
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0cbf32b52191f484cbaad25790820316, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -103.37322
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0cbf32b52191f484cbaad25790820316, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0cbf32b52191f484cbaad25790820316, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0cbf32b52191f484cbaad25790820316, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0cbf32b52191f484cbaad25790820316, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0cbf32b52191f484cbaad25790820316, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0cbf32b52191f484cbaad25790820316, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0cbf32b52191f484cbaad25790820316, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0cbf32b52191f484cbaad25790820316, type: 3}
+      propertyPath: m_Name
+      value: building_tower_B_blue
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0cbf32b52191f484cbaad25790820316, type: 3}
+--- !u!4 &1798522771 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0cbf32b52191f484cbaad25790820316, type: 3}
+  m_PrefabInstance: {fileID: 1798522770}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1807892384
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 962195735}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: d76c4d59d5413e74099b16e9be35f12d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 47.35501
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d76c4d59d5413e74099b16e9be35f12d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.4338722
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d76c4d59d5413e74099b16e9be35f12d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -52.71073
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d76c4d59d5413e74099b16e9be35f12d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.2622089
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d76c4d59d5413e74099b16e9be35f12d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000002135962
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d76c4d59d5413e74099b16e9be35f12d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.9650111
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d76c4d59d5413e74099b16e9be35f12d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.000000078610164
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d76c4d59d5413e74099b16e9be35f12d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d76c4d59d5413e74099b16e9be35f12d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -149.598
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d76c4d59d5413e74099b16e9be35f12d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: d76c4d59d5413e74099b16e9be35f12d, type: 3}
+      propertyPath: m_Name
+      value: building_barracks_blue
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d76c4d59d5413e74099b16e9be35f12d, type: 3}
+--- !u!4 &1807892385 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: d76c4d59d5413e74099b16e9be35f12d, type: 3}
+  m_PrefabInstance: {fileID: 1807892384}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1839843317
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 87.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.629165
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (35)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &1839843318 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 1839843317}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1897557167
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 962195735}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 57.10501
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.4338722
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -69.59823
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.6403189
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.000000035993722
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.76810926
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.000000073077096
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 259.63098
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_Name
+      value: building_archeryrange_blue
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+--- !u!4 &1897557168 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+  m_PrefabInstance: {fileID: 1897557167}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1906798633
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -61.920815
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+      propertyPath: m_Name
+      value: hex_road_A
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+--- !u!4 &1906798634 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 7e6dbba99c5d09f4a812ccb04c819906, type: 3}
+  m_PrefabInstance: {fileID: 1906798633}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1909877539
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -28.145824
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0129e903876400642b4913d621209c8f, type: 3}
+      propertyPath: m_Name
+      value: tree_single_A (8)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0129e903876400642b4913d621209c8f, type: 3}
+--- !u!4 &1909877540 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0129e903876400642b4913d621209c8f, type: 3}
+  m_PrefabInstance: {fileID: 1909877539}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1933403474
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 1ee7d7422e4f7fe4fb7d84502466754d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 27.541128
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ee7d7422e4f7fe4fb7d84502466754d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.842171e-14
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ee7d7422e4f7fe4fb7d84502466754d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -61.855537
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ee7d7422e4f7fe4fb7d84502466754d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ee7d7422e4f7fe4fb7d84502466754d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ee7d7422e4f7fe4fb7d84502466754d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ee7d7422e4f7fe4fb7d84502466754d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ee7d7422e4f7fe4fb7d84502466754d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ee7d7422e4f7fe4fb7d84502466754d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ee7d7422e4f7fe4fb7d84502466754d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 1ee7d7422e4f7fe4fb7d84502466754d, type: 3}
+      propertyPath: m_Name
+      value: tent
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1ee7d7422e4f7fe4fb7d84502466754d, type: 3}
+--- !u!1001 &1949116520
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -11.258329
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (30)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &1949116521 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 1949116520}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1975947732
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 107.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -61.920815
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (23)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &1975947733 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 1975947732}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1977722981
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 78
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -11.258329
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (19)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &1977722982 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 1977722981}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1988683827
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 39
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -45.03332
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.49999994
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.86602545
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+      propertyPath: m_Name
+      value: hex_road_M (4)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+--- !u!4 &1988683828 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 606003f7ff0d4d84685def67869dfce6, type: 3}
+  m_PrefabInstance: {fileID: 1988683827}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2010261262
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: a0da8f8ac096b10498211fe5b161eb66, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 107.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a0da8f8ac096b10498211fe5b161eb66, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a0da8f8ac096b10498211fe5b161eb66, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -61.920815
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a0da8f8ac096b10498211fe5b161eb66, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a0da8f8ac096b10498211fe5b161eb66, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a0da8f8ac096b10498211fe5b161eb66, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a0da8f8ac096b10498211fe5b161eb66, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a0da8f8ac096b10498211fe5b161eb66, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a0da8f8ac096b10498211fe5b161eb66, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a0da8f8ac096b10498211fe5b161eb66, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: a0da8f8ac096b10498211fe5b161eb66, type: 3}
+      propertyPath: m_Name
+      value: cloud_small
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0da8f8ac096b10498211fe5b161eb66, type: 3}
+--- !u!4 &2010261263 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: a0da8f8ac096b10498211fe5b161eb66, type: 3}
+  m_PrefabInstance: {fileID: 2010261262}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2030174730
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 962195735}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: cfafeee41dd45244b9cfab0db281d6d6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.144987
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: cfafeee41dd45244b9cfab0db281d6d6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.4338722
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: cfafeee41dd45244b9cfab0db281d6d6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -52.71073
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: cfafeee41dd45244b9cfab0db281d6d6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: cfafeee41dd45244b9cfab0db281d6d6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: cfafeee41dd45244b9cfab0db281d6d6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: cfafeee41dd45244b9cfab0db281d6d6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: cfafeee41dd45244b9cfab0db281d6d6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: cfafeee41dd45244b9cfab0db281d6d6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: cfafeee41dd45244b9cfab0db281d6d6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: cfafeee41dd45244b9cfab0db281d6d6, type: 3}
+      propertyPath: m_Name
+      value: building_tower_A_blue
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: cfafeee41dd45244b9cfab0db281d6d6, type: 3}
+--- !u!4 &2030174731 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: cfafeee41dd45244b9cfab0db281d6d6, type: 3}
+  m_PrefabInstance: {fileID: 2030174730}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2047835869
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 29.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -95.69581
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+      propertyPath: m_Name
+      value: waterplant_A (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+--- !u!4 &2047835870 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 689d06d6254a2d4458bc70c767292eaa, type: 3}
+  m_PrefabInstance: {fileID: 2047835869}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2102874053
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 39
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -112.5833
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.49999994
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.86602545
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_Name
+      value: hex_coast_C
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+--- !u!4 &2102874054 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+  m_PrefabInstance: {fileID: 2102874053}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2113496594
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -11.258329
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+      propertyPath: m_Name
+      value: trees_A_medium (3)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+--- !u!4 &2113496595 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 1ef54511ef282ef438364aa71c7753be, type: 3}
+  m_PrefabInstance: {fileID: 2113496594}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2114155302
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 78
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -78.80831
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+      propertyPath: m_Name
+      value: hex_coast_C
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+--- !u!4 &2114155303 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 005e5339625fc4843a100487e33cff94, type: 3}
+  m_PrefabInstance: {fileID: 2114155302}
   m_PrefabAsset: {fileID: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
@@ -1640,7 +7543,12 @@ SceneRoots:
   - {fileID: 453287303}
   - {fileID: 962195735}
   - {fileID: 1116592874}
-  - {fileID: 1840913047}
-  - {fileID: 912768704}
-  - {fileID: 20042100}
-  - {fileID: 1574835935}
+  - {fileID: 1552792779}
+  - {fileID: 56756623}
+  - {fileID: 238420128}
+  - {fileID: 1933403474}
+  - {fileID: 811462061}
+  - {fileID: 164659496}
+  - {fileID: 186572040}
+  - {fileID: 134833497}
+  - {fileID: 1191176550}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -38,7 +38,6 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -104,7 +103,7 @@ NavMeshSettings:
   serializedVersion: 2
   m_ObjectHideFlags: 0
   m_BuildSettings:
-    serializedVersion: 2
+    serializedVersion: 3
     agentTypeID: 0
     agentRadius: 0.5
     agentHeight: 2
@@ -117,15 +116,125 @@ NavMeshSettings:
     cellSize: 0.16666667
     manualTileSize: 0
     tileSize: 256
-    accuratePlacement: 0
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &363803587
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.588573
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.8542564
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.9091635
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &363803588 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 363803587}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &453287302
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 453287303}
+  m_Layer: 0
+  m_Name: tiles
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &453287303
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 453287302}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 11.588573, y: -2.8542564, z: -4.9091635}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 363803588}
+  - {fileID: 1311341913}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &705507993
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 705507995}
@@ -141,15 +250,18 @@ GameObject:
 Light:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 705507993}
   m_Enabled: 1
-  serializedVersion: 8
+  serializedVersion: 10
   m_Type: 1
+  m_Shape: 0
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
   m_Intensity: 1
   m_Range: 10
   m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
   m_CookieSize: 10
   m_Shadows:
     m_Type: 2
@@ -159,6 +271,24 @@ Light:
     m_Bias: 0.05
     m_NormalBias: 0.4
     m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
   m_Cookie: {fileID: 0}
   m_DrawHalo: 0
   m_Flare: {fileID: 0}
@@ -166,32 +296,71 @@ Light:
   m_CullingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+  m_RenderingLayerMask: 1
   m_Lightmapping: 1
   m_LightShadowCasterMode: 0
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &705507995
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 705507993}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
   m_LocalPosition: {x: 0, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &962195734
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 962195735}
+  m_Layer: 0
+  m_Name: builds
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &962195735
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 962195734}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.3949871, y: -1.4338722, z: 2.0482464}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1897557168}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 963194228}
@@ -208,24 +377,35 @@ GameObject:
 AudioListener:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 963194225}
   m_Enabled: 1
 --- !u!20 &963194227
 Camera:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 963194225}
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 1
   m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
   m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_GateFitMode: 2
-  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -256,12 +436,228 @@ Camera:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 963194225}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1116592874
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.64838004
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.76131684
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -99.161
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
+      propertyPath: m_Name
+      value: Knight
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
+--- !u!1001 &1311341912
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8.411427
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.9
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &1311341913 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 1311341912}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1897557167
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 962195735}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.3949871
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.4338722
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.0482464
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.83849025
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000006830381
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.5449167
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.000000044389108
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 66.038
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+      propertyPath: m_Name
+      value: building_archeryrange_blue
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+--- !u!4 &1897557168 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 00450ed0ce7043d419e7472f321e025f, type: 3}
+  m_PrefabInstance: {fileID: 1897557167}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 963194228}
+  - {fileID: 705507995}
+  - {fileID: 453287303}
+  - {fileID: 962195735}
+  - {fileID: 1116592874}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -122,6 +122,137 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &20042100
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 68.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -84.43748
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_Name
+      value: hex_water
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+--- !u!1001 &158440188
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 48.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -61.920815
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (5)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &158440189 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 158440188}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &363803587
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -221,7 +352,7 @@ Transform:
   m_GameObject: {fileID: 453287302}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 11.588573, y: -2.8542564, z: -4.9091635}
+  m_LocalPosition: {x: 9.75, y: 0, z: -5.629165}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -230,8 +361,89 @@ Transform:
   - {fileID: 764619313}
   - {fileID: 1961491158}
   - {fileID: 1656469854}
+  - {fileID: 158440189}
+  - {fileID: 1773018901}
+  - {fileID: 684809487}
+  - {fileID: 1746552037}
+  - {fileID: 1669359595}
+  - {fileID: 1823846778}
+  - {fileID: 1106259831}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &684809486
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 58.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -45.03332
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (7)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &684809487 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 684809486}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &705507993
 GameObject:
   m_ObjectHideFlags: 0
@@ -320,7 +532,7 @@ Transform:
   m_GameObject: {fileID: 705507993}
   serializedVersion: 2
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
-  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -348,15 +560,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 27.411427
+      value: 29.25
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.8542564
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -62.640816
+      value: -61.920815
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalRotation.w
@@ -400,6 +612,63 @@ Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
   m_PrefabInstance: {fileID: 764619312}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &912768704
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 5188be284f4561247a2983d4660c8eac, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 78
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5188be284f4561247a2983d4660c8eac, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5188be284f4561247a2983d4660c8eac, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -67.54998
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5188be284f4561247a2983d4660c8eac, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5188be284f4561247a2983d4660c8eac, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5188be284f4561247a2983d4660c8eac, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5188be284f4561247a2983d4660c8eac, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5188be284f4561247a2983d4660c8eac, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5188be284f4561247a2983d4660c8eac, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5188be284f4561247a2983d4660c8eac, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 5188be284f4561247a2983d4660c8eac, type: 3}
+      propertyPath: m_Name
+      value: hex_grass_sloped_low
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5188be284f4561247a2983d4660c8eac, type: 3}
 --- !u!1 &962195734
 GameObject:
   m_ObjectHideFlags: 0
@@ -518,12 +787,74 @@ Transform:
   m_GameObject: {fileID: 963194225}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalPosition: {x: 0, y: 0, z: -11.25833}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1106259830
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 46f94a22149644044a02032c5dac9877, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 78
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 46f94a22149644044a02032c5dac9877, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 46f94a22149644044a02032c5dac9877, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -45.03332
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 46f94a22149644044a02032c5dac9877, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 46f94a22149644044a02032c5dac9877, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 46f94a22149644044a02032c5dac9877, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 46f94a22149644044a02032c5dac9877, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 46f94a22149644044a02032c5dac9877, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 46f94a22149644044a02032c5dac9877, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 46f94a22149644044a02032c5dac9877, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 46f94a22149644044a02032c5dac9877, type: 3}
+      propertyPath: m_Name
+      value: hex_grass_sloped_high (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 46f94a22149644044a02032c5dac9877, type: 3}
+--- !u!4 &1106259831 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 46f94a22149644044a02032c5dac9877, type: 3}
+  m_PrefabInstance: {fileID: 1106259830}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1116592874
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -534,7 +865,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 8
+      value: 9.75
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
       propertyPath: m_LocalPosition.y
@@ -542,7 +873,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 5.629165
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 589b9e809eada2b459fd9879d6ad5b5d, type: 3}
       propertyPath: m_LocalRotation.w
@@ -603,15 +934,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 27.411427
+      value: 29.25
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.8542564
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -28.865826
+      value: -28.145824
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalRotation.w
@@ -655,6 +986,63 @@ Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
   m_PrefabInstance: {fileID: 1311341912}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1574835935
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 58.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -101.324974
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
+      propertyPath: m_Name
+      value: hex_water (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0c9170dd188575d42a2acaae196eaeed, type: 3}
 --- !u!1001 &1656469853
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -677,15 +1065,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 37.161427
+      value: 39
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.8542564
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -45.753323
+      value: -45.03332
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalRotation.w
@@ -728,6 +1116,266 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
   m_PrefabInstance: {fileID: 1656469853}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1669359594
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -78.80831
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_Name
+      value: hex_grass_bottom (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+--- !u!4 &1669359595 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+  m_PrefabInstance: {fileID: 1669359594}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1746552036
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 39
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -78.80831
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_Name
+      value: hex_grass_bottom
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+--- !u!4 &1746552037 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+  m_PrefabInstance: {fileID: 1746552036}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1773018900
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 48.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -28.145824
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+      propertyPath: m_Name
+      value: hex_grass (6)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+--- !u!4 &1773018901 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
+  m_PrefabInstance: {fileID: 1773018900}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1823846777
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 453287303}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -61.920815
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.00000008146034
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+      propertyPath: m_Name
+      value: hex_grass_bottom (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+--- !u!4 &1823846778 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 582d4ebe5c2877343ae366bdec6e72fd, type: 3}
+  m_PrefabInstance: {fileID: 1823846777}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1840913043
 GameObject:
@@ -931,15 +1579,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 17.661427
+      value: 19.5
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.8542564
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -45.753323
+      value: -45.03332
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: aa1b918bad9b9ab45b3945c8001e4309, type: 3}
       propertyPath: m_LocalRotation.w
@@ -993,3 +1641,6 @@ SceneRoots:
   - {fileID: 962195735}
   - {fileID: 1116592874}
   - {fileID: 1840913047}
+  - {fileID: 912768704}
+  - {fileID: 20042100}
+  - {fileID: 1574835935}

--- a/ProjectSettings/SceneTemplateSettings.json
+++ b/ProjectSettings/SceneTemplateSettings.json
@@ -1,0 +1,121 @@
+{
+    "templatePinStates": [],
+    "dependencyTypeInfos": [
+        {
+            "userAdded": false,
+            "type": "UnityEngine.AnimationClip",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.Animations.AnimatorController",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.AnimatorOverrideController",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.Audio.AudioMixerController",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.ComputeShader",
+            "defaultInstantiationMode": 1
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Cubemap",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.GameObject",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.LightingDataAsset",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.LightingSettings",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Material",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.MonoScript",
+            "defaultInstantiationMode": 1
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.PhysicMaterial",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.PhysicsMaterial2D",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.PostProcessing.PostProcessProfile",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.PostProcessing.PostProcessResources",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.VolumeProfile",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.SceneAsset",
+            "defaultInstantiationMode": 1
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Shader",
+            "defaultInstantiationMode": 1
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.ShaderVariantCollection",
+            "defaultInstantiationMode": 1
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Texture",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Texture2D",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Timeline.TimelineAsset",
+            "defaultInstantiationMode": 0
+        }
+    ],
+    "defaultDependencyTypeInfo": {
+        "userAdded": false,
+        "type": "<default_scene_template_dependencies>",
+        "defaultInstantiationMode": 1
+    },
+    "newSceneOverride": 0
+}


### PR DESCRIPTION
I've attached a script to the editor that adjusts the snap grid mechanic, ensuring our hexagons align perfectly. Please note, this is size-sensitive, so changing tile sizes will disrupt the grid snapper.

Buildings use a factor of 9.5, while tiles use a factor of 10 to maintain consistency with the character assets.

The sample scene includes various tiles, buildings, and props for viewing the assets.